### PR TITLE
Fix README description of `User.status.values`

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Attribute's I18n text value:
 
 #### values
 
-List of I18n text values for an enumerized attribute:
+List of possible values for an enumerized attribute:
 
 ```ruby
 User.status.values # or User.enumerized_attributes[:status].values


### PR DESCRIPTION
`User.status.values` doesn't seem to return "I18n text values" as mentioned in the README, but just "values".

```ruby
class User < ApplicationRecord
  extend Enumerize

  enumerize :status, in: [:student, :employed, :retired]
end
```

with:

```yml
en:
  enumerize:
    user:
      status:
        student: "Student"
        employed: "Employed"
        retired: "Retiree"
```

`User.status.values` will return `["student", "employed", "retired]` and not `["Student", "Employed", "Retiree]`.

Or maybe I'm missing something?